### PR TITLE
Remove_filter() only accepts 3 parameter

### DIFF
--- a/src/Console/MediaGenerateSlugsCommand.php
+++ b/src/Console/MediaGenerateSlugsCommand.php
@@ -139,7 +139,7 @@ class MediaGenerateSlugsCommand extends Command
                 return;
             }
 
-            remove_filter('wp_unique_post_slug', [$this->package, 'randomizeAttachmentSlug'], 10, 4);
+            remove_filter('wp_unique_post_slug', [$this->package, 'randomizeAttachmentSlug']);
 
             $slug = $attachment['title'] ?: Str::beforeLast($filename, '.');
 


### PR DESCRIPTION
The function `remove_filter()` https://developer.wordpress.org/reference/functions/remove_filter/ only accepts 3 parameter.
$priority = 10 is the default.